### PR TITLE
only try to use lunr_lang if @language is not "en"

### DIFF
--- a/lib/middleman-search/search-index-resource.rb
+++ b/lib/middleman-search/search-index-resource.rb
@@ -63,7 +63,7 @@ module Middleman
           end
 
           # Define fields with boost
-          this.use(lunr_lang) if @language
+          this.use(lunr_lang) if @language != 'en'
           @fields.each do |field, opts|
             next if opts[:index] == false
             this.field(field, {:boost => opts[:boost]})


### PR DESCRIPTION
If no search.language is set then building the site fails. Setting the language to "es" and the index builds.

This pull request only tries to use lunr_lang if `@language` is not "en" since lunr_lang only gets defined if the language is not "en".

This is the error that I get:

```
at t.Index.use (/home/jnronall/.rvm/gems/ruby-2.3.1/bundler/gems/middleman-search-3be9d42770f1/vendor/assets/javascripts/lunr.min.js:7:10009): Cannot call method 'apply' of null (V8::Error)
	from /home/jnronall/.rvm/gems/ruby-2.3.1/bundler/gems/middleman-search-3be9d42770f1/lib/middleman-search/search-index-resource.rb:66:in `block in build_index'
	from at t (/home/jnronall/.rvm/gems/ruby-2.3.1/bundler/gems/middleman-search-3be9d42770f1/vendor/assets/javascripts/lunr.min.js:7:114)
	from /home/jnronall/.rvm/gems/ruby-2.3.1/bundler/gems/middleman-search-3be9d42770f1/lib/middleman-search/search-index-resource.rb:74:in `build_index'
	from /home/jnronall/.rvm/gems/ruby-2.3.1/bundler/gems/middleman-search-3be9d42770f1/lib/middleman-search/search-index-resource.rb:29:in `render'
```