### PR TITLE
add support for multiple instances

### DIFF
--- a/lib/middleman-search/extension.rb
+++ b/lib/middleman-search/extension.rb
@@ -3,6 +3,9 @@ require 'middleman-search/search-index-resource'
 
 module Middleman
   class SearchExtension < Middleman::Extension
+
+    self.supports_multiple_instances = true
+
     option :resources, [], 'Paths of resources to index'
     option :fields, {}, 'Fields to index, with their options'
     option :before_index, nil, 'Callback to execute before indexing a document'


### PR DESCRIPTION
Nothing seems to stand in the way of that, and I need it for a multilingual website. I want to have two search.json's: one for each language. This way I can include the Dutch search in the Dutch website, and the English search in the English website.

I have this in my config.rb:

```ruby
# First locale is considered root path
locales = [:en, :nl]
activate :i18n do |i18n|
  i18n.templates_dir = "pages"
  i18n.locales = locales
end

locales.each do | locale |
  activate :search do |search|
    search.resources = ["blog/#{locale}", "#{locale}/helpdesk/"]
    search.index_path = "search/lunr-index-#{locale}.json"
    search.fields = {
      title:   {boost: 100, store: true, required: true},
      content: {boost: 50},
      url:     {index: false, store: true},
      author:  {boost: 30}
    }
  end
end
```

(note that we're also using blog, if you think it's relevant:)

```ruby
locales.each_with_index do | locale, index |
  # Blog
  activate :blog do | blog |
    # Locale path: first locale is mounted at root
    path = index > 0 ? "#{locale}/" : ""
    blog.name      = "blog_#{locale}"
    blog.permalink = "#{path}blog/{year}/{month}/{day}/{title}.html"
    # Matcher for blog source files
    blog.sources = "blog/#{locale}/{year}-{month}-{day}-{engtitle}.html"
    blog.layout    = "blog"

    # Pagination
    blog.paginate  = true
    blog.page_link = "page/{num}"
    blog.per_page  = 15

    # Calendar
    blog.calendar_template = "blog/calendar.html"
    blog.year_link         = "#{path}blog/{year}.html"
    blog.month_link        = "#{path}blog/{year}/{month}.html"
    blog.day_link          = "#{path}blog/{year}/{month}/{day}.html"

    # Tags
    blog.tag_template = "blog/tag.html"
    blog.taglink      = "#{path}blog/tag/{tag}.html"
    # Use the global Middleman I18n.locale instead of the lang in the
    # article's frontmatter
    blog.preserve_locale = true
  end
end

```